### PR TITLE
credentials: no need for the private struct

### DIFF
--- a/aws-glib/aws-credentials.c
+++ b/aws-glib/aws-credentials.c
@@ -20,18 +20,15 @@
 
 #include "aws-credentials.h"
 
-typedef struct
-{
-  gchar *access_key;
-  gchar *secret_key;
-} AwsCredentialsPrivate;
-
 struct _AwsCredentials
 {
   GObject parent_instance;
+
+  gchar *access_key;
+  gchar *secret_key;
 };
 
-G_DEFINE_TYPE_WITH_PRIVATE (AwsCredentials, aws_credentials, G_TYPE_OBJECT)
+G_DEFINE_TYPE (AwsCredentials, aws_credentials, G_TYPE_OBJECT)
 
 enum {
    PROP_0,
@@ -68,35 +65,29 @@ aws_credentials_new (const gchar *access_key,
 const gchar *
 aws_credentials_get_access_key (AwsCredentials *self)
 {
-  AwsCredentialsPrivate *priv = aws_credentials_get_instance_private (self);
-
   g_return_val_if_fail (AWS_IS_CREDENTIALS (self), NULL);
 
-  return priv->access_key;
+  return self->access_key;
 }
 
 const gchar *
 aws_credentials_get_secret_key (AwsCredentials *self)
 {
-  AwsCredentialsPrivate *priv = aws_credentials_get_instance_private (self);
-
   g_return_val_if_fail (AWS_IS_CREDENTIALS (self), NULL);
 
-  return priv->secret_key;
+  return self->secret_key;
 }
 
 void
 aws_credentials_set_access_key (AwsCredentials *self,
                                 const gchar    *access_key)
 {
-  AwsCredentialsPrivate *priv = aws_credentials_get_instance_private (self);
-
   g_return_if_fail (AWS_IS_CREDENTIALS (self));
 
-  if (g_strcmp0 (priv->access_key, access_key) != 0)
+  if (g_strcmp0 (self->access_key, access_key) != 0)
     {
-      str_zero_and_free (priv->access_key);
-      priv->access_key = g_strdup (priv->access_key);
+      str_zero_and_free (self->access_key);
+      self->access_key = g_strdup (self->access_key);
       g_object_notify_by_pspec (G_OBJECT (self), properties [PROP_ACCESS_KEY]);
     }
 }
@@ -105,14 +96,12 @@ void
 aws_credentials_set_secret_key (AwsCredentials *self,
                                 const gchar    *secret_key)
 {
-  AwsCredentialsPrivate *priv = aws_credentials_get_instance_private (self);
-
   g_return_if_fail (AWS_IS_CREDENTIALS (self));
 
-  if (g_strcmp0 (priv->secret_key, secret_key) != 0)
+  if (g_strcmp0 (self->secret_key, secret_key) != 0)
     {
-      str_zero_and_free (priv->secret_key);
-      priv->secret_key = g_strdup (priv->secret_key);
+      str_zero_and_free (self->secret_key);
+      self->secret_key = g_strdup (self->secret_key);
       g_object_notify_by_pspec (G_OBJECT (self), properties [PROP_SECRET_KEY]);
     }
 }
@@ -133,7 +122,6 @@ aws_credentials_sign (AwsCredentials *self,
                       gssize          text_len,
                       GChecksumType   digest_type)
 {
-  AwsCredentialsPrivate *priv = aws_credentials_get_instance_private (self);
   g_autofree guint8 *digest = NULL;
   g_autofree gchar *signature = NULL;
   g_autoptr(GHmac) hmac = NULL;
@@ -141,7 +129,7 @@ aws_credentials_sign (AwsCredentials *self,
 
   g_return_val_if_fail (AWS_IS_CREDENTIALS (self), NULL);
   g_return_val_if_fail (text != NULL, NULL);
-  g_return_val_if_fail (priv->secret_key != NULL, NULL);
+  g_return_val_if_fail (self->secret_key != NULL, NULL);
   g_return_val_if_fail (digest_type == G_CHECKSUM_SHA1 ||
                         digest_type == G_CHECKSUM_SHA256, NULL);
 
@@ -156,8 +144,8 @@ aws_credentials_sign (AwsCredentials *self,
 
   digest = g_malloc (digest_len);
   hmac = g_hmac_new (digest_type,
-                     (const guint8 *)priv->secret_key,
-                     strlen (priv->secret_key));
+                     (const guint8 *)self->secret_key,
+                     strlen (self->secret_key));
   g_hmac_update (hmac, (const guint8 *)text, text_len);
   g_hmac_get_digest (hmac, digest, &digest_len);
   signature = g_base64_encode (digest, digest_len);
@@ -169,10 +157,9 @@ static void
 aws_credentials_finalize (GObject *object)
 {
   AwsCredentials *self = (AwsCredentials *)object;
-  AwsCredentialsPrivate *priv = aws_credentials_get_instance_private (self);
 
-  g_clear_pointer (&priv->access_key, str_zero_and_free);
-  g_clear_pointer (&priv->secret_key, str_zero_and_free);
+  g_clear_pointer (&self->access_key, str_zero_and_free);
+  g_clear_pointer (&self->secret_key, str_zero_and_free);
 
   G_OBJECT_CLASS (aws_credentials_parent_class)->finalize (object);
 }


### PR DESCRIPTION
It is a final type anyway so avoid the overhead.